### PR TITLE
Update link hover color

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -170,8 +170,7 @@ a {
     border-bottom: 1px solid #fff;
 
     &:hover, &:focus {
-      color: lighten($teal, 42%);
-      border-bottom: 1px solid lighten($teal, 42%);
+      border-bottom: 1px solid rgb(47, 47, 47);
     }
   }
 }


### PR DESCRIPTION
I added the lightened teal to the hover. I think that the original color is actually much better, as it is a good neutral against the burnt orange. Below is an image of the hover teal and the original color in the "Book Now" link:

<img width="741" alt="hover_teal_lighten" src="https://user-images.githubusercontent.com/6877456/56400834-ed87fb00-6223-11e9-9f60-58cd283500ba.png">

I also added a border to the bottom of the link and adjusted for some padding to add space below the border.